### PR TITLE
Fix colour popup authentication popup on login

### DIFF
--- a/roles/xrdp/files/02-allow-colord.conf
+++ b/roles/xrdp/files/02-allow-colord.conf
@@ -1,0 +1,11 @@
+polkit.addRule(function(action, subject) {
+ if ((action.id == "org.freedesktop.color-manager.create-device" ||
+    action.id == "org.freedesktop.color-manager.create-profile" ||
+    action.id == "org.freedesktop.color-manager.delete-device" ||
+    action.id == "org.freedesktop.color-manager.delete-profile" ||
+    action.id == "org.freedesktop.color-manager.modify-device" ||
+    action.id == "org.freedesktop.color-manager.modify-profile") &&
+    subject.isInGroup("{users}")) {
+        return polkit.Result.YES;
+    }
+});

--- a/roles/xrdp/tasks/xrdp-debian.yml
+++ b/roles/xrdp/tasks/xrdp-debian.yml
@@ -27,3 +27,11 @@
     name: xrdp
     state: restarted
     enabled: yes
+
+- name: Fix colour profile authentication popup on login
+  become: yes
+  copy:
+    src: 02-allow-colord.conf
+    dest: /etc/polkit-1/localauthority.conf.d
+
+      


### PR DESCRIPTION
Removes the colour profile authentication popup during login.  Fix is from:
https://c-nergy.be/blog/?p=12073